### PR TITLE
fix: NCIATWP-9342 add aria-disabled to grayed-out containers for 508 …

### DIFF
--- a/client/src/modules/run-scenario/run-scenario.js
+++ b/client/src/modules/run-scenario/run-scenario.js
@@ -943,6 +943,7 @@ export default function RunScenarios() {
                                   opacity: 1.0}}
                                 onChange={handleRangeChange} // Update state on change
                                 allowCross={false} // Prevent handles from crossing
+                                ariaLabelForHandle={['Ages initiating cervical screening', 'Ages ending cervical screening']}
                                 range 
                               />
                               <br />
@@ -1397,6 +1398,7 @@ export default function RunScenarios() {
                                                       ? "grayed-out"
                                                       : ""
                                                   }`}
+                                                  aria-disabled={hpv16or18Used || hpvUsed}
                                                 >
                                                   <Form.Range
                                                     type="number"
@@ -1413,9 +1415,10 @@ export default function RunScenarios() {
                                                     onWheel={(e) =>
                                                       e.target.blur()
                                                     }
+                                                    disabled={hpv16or18Used || hpvUsed}
                                                     required
                                                   />
-                                                  <span className="text-nowrap">
+                                                  <span className="text-nowrap" aria-hidden={hpv16or18Used || hpvUsed}>
                                                     {
                                                       form.screeningTestSpecificity
                                                     }{" "}
@@ -1436,6 +1439,7 @@ export default function RunScenarios() {
                                               ? "grayed-out"
                                               : "d-none"
                                           }
+                                          aria-disabled={checkedValues.length === 2}
                                         >
                                           <div className="ps-3">
                                             <div>
@@ -1703,6 +1707,7 @@ export default function RunScenarios() {
                                                       ? "grayed-out"
                                                       : ""
                                                   }`}
+                                                    aria-disabled={hpv16or18GenotypingTriageUsed || checkedValues.length === 2}
                                                 >
                                                     <Form.Range
                                                       type="number"
@@ -1745,6 +1750,7 @@ export default function RunScenarios() {
                                               ? "grayed-out"
                                               : "d-none"
                                           }
+                                          aria-disabled={checkedValues.length === 3 && checkedValues.includes("ScreenDiagnosticTestTreat")}
                                         >
                                           <div className="ps-3">
                                             {" "}
@@ -2117,6 +2123,7 @@ export default function RunScenarios() {
                                                         ? "grayed-out"
                                                         : ""
                                                     }`}
+                                                    aria-disabled={hpv16or18Used}
                                                   >
                                                     <Form.Range
                                                       type="number"
@@ -2351,6 +2358,7 @@ export default function RunScenarios() {
                                                       ? "grayed-out"
                                                       : ""
                                                   }`}
+                                                   aria-disabled={hpv16or18GenotypingTriageUsed}
                                                 >
                                                     <Form.Range
                                                       type="number"
@@ -2726,6 +2734,7 @@ export default function RunScenarios() {
                                                       ? "grayed-out"
                                                       : ""
                                                   }`}
+                                                   aria-disabled={hpv16or18GenotypingTriageUsed}
                                                 >
                                                     <Form.Range
                                                       type="number"
@@ -2769,6 +2778,7 @@ export default function RunScenarios() {
                                               ? "grayed-out"
                                               : "d-none"
                                           }
+                                          aria-disabled={checkedValues.length === 2}
                                         >
                                           <Row>
                                             <Form.Group
@@ -3061,6 +3071,7 @@ export default function RunScenarios() {
                                               ? "grayed-out"
                                               : "d-none"
                                           }
+                                          aria-disabled={checkedValues.length === 3 && checkedValues.includes("ScreenTriageDiagnosticTestTreat")}
                                         >
                                           <Row>
                                             <Form.Group
@@ -3623,6 +3634,7 @@ export default function RunScenarios() {
                                                       ? "grayed-out"
                                                       : ""
                                                   }`}
+                                                  aria-disabled={hpv16or18GenotypingTriageUsed}
                                                 >
                                                   <Form.Range
                                                     type="number"
@@ -3736,6 +3748,7 @@ export default function RunScenarios() {
                                                           ? "grayed-out"
                                                           : ""
                                                       }`}
+                                                      aria-disabled={hpv16or18Used}
                                                     >
                                                       <Form.Range
                                                         type="number"


### PR DESCRIPTION
CC3S ([NCIATWP-9342](https://tracker.nci.nih.gov/browse/NCIATWP-9342))

 Fixes all axe-flagged 508 accessibility issues in run-scenario.js:
 - Added aria-disabled to 11 grayed-out form containers to invoke WCAG 1.4.3 inactive component exception
 - Added ariaLabelForHandle to Slider component for accessible range input labels
 
 0 axe violations remaining.